### PR TITLE
Fix comment in useOnClickOutside

### DIFF
--- a/src/hooks/useOnClickOutside.js
+++ b/src/hooks/useOnClickOutside.js
@@ -6,7 +6,7 @@ const useOnClickOutside = (ref, handler) => {
   useEffect(
     () => {
       const listener = event => {
-        // Do nothing if clicking ref's element or descendent elements
+        // Do nothing if clicking ref's element or descendant elements
         if (!ref.current || ref.current.contains(event.target)) {
           return;
         }


### PR DESCRIPTION
## Summary
- fix typo in useOnClickOutside.js comment

## Testing
- `npm run format` *(fails: Cannot find module '@upstatement/prettier-config')*