### PR TITLE
Fix GlobalStyle semicolon

### DIFF
--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -8,7 +8,7 @@ const GlobalStyle = createGlobalStyle`
 
   :root {
     --main-blue: #054e5b;
-    --main-black: #1d1d1f
+    --main-black: #1d1d1f;
     --light-grey: #c0c0c0;
     --dark-navy: #fafafa;
     --navy: #fafafa;


### PR DESCRIPTION
## Summary
- add missing semicolon for main black color

## Testing
- `npm run format` *(fails: Cannot find module '@upstatement/prettier-config')*