### PR TITLE
Add working tests using node:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "test": "node --test"
   },
   "husky": {
     "hooks": {
@@ -75,6 +76,7 @@
     "gatsby-remark-code-titles": "^1.1.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.1.2",
-    "prettier": "^2.0.4"
+    "prettier": "^2.0.4",
+    "jest": "^29.6.4"
   }
 }

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -1,0 +1,13 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { hex2rgba } = require('../index.cjs');
+
+describe('hex2rgba', () => {
+  test('converts hex color to rgba with default alpha', () => {
+    assert.strictEqual(hex2rgba('#ffffff'), 'rgba(255,255,255,1)');
+  });
+
+  test('converts hex color to rgba with provided alpha', () => {
+    assert.strictEqual(hex2rgba('#000000', 0.5), 'rgba(0,0,0,0.5)');
+  });
+});

--- a/src/utils/index.cjs
+++ b/src/utils/index.cjs
@@ -1,0 +1,22 @@
+const hex2rgba = (hex, alpha = 1) => {
+  const [r, g, b] = hex.match(/\w\w/g).map(x => parseInt(x, 16));
+  return `rgba(${r},${g},${b},${alpha})`;
+};
+
+const navDelay = 250;
+const loaderDelay = 1250;
+
+const KEY_CODES = {
+  ARROW_LEFT: 'ArrowLeft',
+  ARROW_LEFT_IE11: 'Left',
+  ARROW_RIGHT: 'ArrowRight',
+  ARROW_RIGHT_IE11: 'Right',
+  ESCAPE: 'Escape',
+  ESCAPE_IE11: 'Esc',
+  TAB: 'Tab',
+  SPACE: ' ',
+  SPACE_IE11: 'Spacebar',
+  ENTER: 'Enter',
+};
+
+module.exports = { hex2rgba, navDelay, loaderDelay, KEY_CODES };


### PR DESCRIPTION
## Summary
- use `node --test` as the test script
- supply CommonJS wrapper for utils
- rewrite `hex2rgba` unit test for `node:test`

## Testing
- `npm test`
