### PR TITLE
Fix robots.txt plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gatsby-plugin-offline": "^3.0.27",
     "gatsby-plugin-react-helmet": "^3.1.16",
     "gatsby-plugin-react-svg": "^3.0.0",
-    "gatsby-plugin-robots-txt": "^1.5.0",
+    "gatsby-plugin-robots-txt": "1.5.0",
     "gatsby-plugin-sharp": "^2.3.5",
     "gatsby-plugin-sitemap": "^2.2.22",
     "gatsby-plugin-styled-components": "^3.1.14",


### PR DESCRIPTION
## Summary
- pin `gatsby-plugin-robots-txt` version to `1.5.0`

## Testing
- `npm test`
- `yarn install` *(fails: RequestError EHOSTUNREACH)*