### PR TITLE
Fix robots.txt plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gatsby-plugin-offline": "^3.0.27",
     "gatsby-plugin-react-helmet": "^3.1.16",
     "gatsby-plugin-react-svg": "^3.0.0",
-    "gatsby-plugin-robots-txt": "^1.5.0",
+    "gatsby-plugin-robots-txt": "1.5.0",
     "gatsby-plugin-sharp": "^2.3.5",
     "gatsby-plugin-sitemap": "^2.2.22",
     "gatsby-plugin-styled-components": "^3.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,7 +5916,7 @@
   dependencies:
     "svg-react-loader" "^0.4.4"
 
-"gatsby-plugin-robots-txt@^1.5.0":
+"gatsby-plugin-robots-txt@1.5.0":
   "integrity" "sha512-gm59CjF0pUS0/U7JUX6988NQrE7CNljnb2CGFCl655iq1K6PF+bimuYNGrIy8N/19OEmK9kl/d1Xx+V+ooZN7Q=="
   "resolved" "https://registry.yarnpkg.com/gatsby-plugin-robots-txt/-/gatsby-plugin-robots-txt-1.5.0.tgz"
   "version" "1.5.0"


### PR DESCRIPTION
## Summary
- pin `gatsby-plugin-robots-txt` version to `1.5.0`
- update lockfile to match

## Testing
- `npm test`
- `yarn install --immutable --check-cache` *(fails: RequestError EHOSTUNREACH)*
